### PR TITLE
add Page Views

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Demo Java Web App
+[![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2Ftongueroo%2Fdemo-java&count_bg=%2379C83D&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=PAGE+VIEWS&edge_flat=false)](https://hits.seeyoufarm.com)
 
 [![BoltOps Badge](https://img.boltops.com/boltops/badges/boltops-badge.png)](https://www.boltops.com)
 


### PR DESCRIPTION
When we add this service, it will count every hit of this repo. And this will guide us more about the visitors each day and will indicate the total views. For me, this is very helpful both for us and for those will view this repo seeing this page views. If there is the website built from this repo, it can be simply added there too.

![Screenshot (1712)](https://user-images.githubusercontent.com/47092464/98458068-f2c2e700-21c7-11eb-9026-6d04966df183.png)
